### PR TITLE
Asynchronous serial transmitter assignment operator does not transfer hardware ownership

### DIFF
--- a/include/picolibrary/microchip/avr/megaavr/asynchronous_serial.h
+++ b/include/picolibrary/microchip/avr/megaavr/asynchronous_serial.h
@@ -130,6 +130,8 @@ class Transmitter {
 
         m_usart = expression.m_usart;
 
+        expression.m_usart = nullptr;
+
         return *this;
     }
 


### PR DESCRIPTION
Resolves #61.