### PR TITLE
GPIO open-drain I/O pin does not handle self assignment

### DIFF
--- a/include/picolibrary/microchip/avr/megaavr/gpio.h
+++ b/include/picolibrary/microchip/avr/megaavr/gpio.h
@@ -260,13 +260,15 @@ class Open_Drain_IO_Pin {
      */
     auto & operator=( Open_Drain_IO_Pin && expression ) noexcept
     {
-        disable();
+        if ( &expression != this ) {
+            disable();
 
-        m_port = expression.m_port;
-        m_mask = expression.m_mask;
+            m_port = expression.m_port;
+            m_mask = expression.m_mask;
 
-        expression.m_port = nullptr;
-        expression.m_mask = 0;
+            expression.m_port = nullptr;
+            expression.m_mask = 0;
+        } // if
 
         return *this;
     }


### PR DESCRIPTION
Resolves #74.